### PR TITLE
Cut down variable names due to having local scope

### DIFF
--- a/_tools.widths.scss
+++ b/_tools.widths.scss
@@ -37,18 +37,18 @@
 // Basically, we just call the mixin again but inside of a breakpoint of our
 // choosing, and with the additional responsive suffix (e.g. `\@large`).
 
-@mixin widths($widths-columns, $widths-breakpoint: null) {
+@mixin widths($columns, $breakpoint: null) {
 
   // Loop through the number of columns for each denominator of our fractions.
-  @each $widths-denominator in $widths-columns {
+  @each $denominator in $columns {
 
     // Begin creating a numerator for our fraction up until we hit the
     // denominator.
-    @for $widths-numerator from 1 through $widths-denominator {
+    @for $numerator from 1 through $denominator {
 
       // Build a class in the format `.u-width-3/4[@<breakpoint>]`.
-      .u-width-#{$widths-numerator}\/#{$widths-denominator}#{$widths-breakpoint} {
-        width: ($widths-numerator / $widths-denominator) * 100% !important;
+      .u-width-#{$numerator}\/#{$denominator}#{$breakpoint} {
+        width: ($numerator / $denominator) * 100% !important;
       }
 
       /**
@@ -56,16 +56,16 @@
        */
 
       // Build a class in the format `.u-push-1/2[@<breakpoint>]`.
-      .u-push-#{$widths-numerator}\/#{$widths-denominator}#{$widths-breakpoint} {
+      .u-push-#{$numerator}\/#{$denominator}#{$breakpoint} {
         position: relative;
         right: auto; /* [1] */
-        left: ($widths-numerator / $widths-denominator) * 100% !important;
+        left: ($numerator / $denominator) * 100% !important;
       }
 
       // Build a class in the format `.u-pull-5/6[@<breakpoint>]`.
-      .u-pull-#{$widths-numerator}\/#{$widths-denominator}#{$widths-breakpoint} {
+      .u-pull-#{$numerator}\/#{$denominator}#{$breakpoint} {
         position: relative;
-        right: ($widths-numerator / $widths-denominator) * 100% !important;
+        right: ($numerator / $denominator) * 100% !important;
         left: auto; /* [1] */
       }
 


### PR DESCRIPTION
I had super-long variable names to avoid collisions, but seeing as the mixin gives us local scope, we ain’t need to namespaces. Makes things smaller and much more readable.
