### PR TITLE
[refs #00012] Rename Supercell main mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,19 +85,19 @@ like to create. To create a 12 column layout system, simply call the mixin like
 so:
 
 ```SCSS
-@include widths(12);
+@include supercell(12);
 ```
 
 To generate a 12 and a 16 column layout system, call the mixin like so:
 
 ```SCSS
-@include widths(12 16);
+@include supercell(12 16);
 ```
 
 To generate a 3, a 4, and an 8 column layout system, call the mixin like so:
 
 ```SCSS
-@include widths(3 4 8);
+@include supercell(3 4 8);
 ```
 
 Supercell will now generate a full suite of classes that will satisfy every
@@ -124,7 +124,7 @@ To generate a 12 column layout system for use on screens over 1200px wide:
 
 ```SCSS
 @media screen and (min-width: 1200px) {
-  @include widths(12, \@large);
+  @include supercell(12, \@large);
 }
 ```
 

--- a/_tools.widths.scss
+++ b/_tools.widths.scss
@@ -20,24 +20,24 @@
 //
 // To create a non-responsive 12 column grid system, simply call:
 //
-//   @include widths(12);
+//   @include supercell(12);
 //
 // To create a 3 and 4 column grid system on medium sized screens:
 //
 //   @media screen and (min-width: 720px) {
-//     @include widths(3 4, \@medium);
+//     @include supercell(3 4, \@medium);
 //   }
 //
 // To create a 1, 2, 3 and 4 column grid system on large sized screens:
 //
 //   @media screen and (min-width: 1024px) {
-//     @include widths(1 2 3 4, \@large);
+//     @include supercell(1 2 3 4, \@large);
 //   }
 //
 // Basically, we just call the mixin again but inside of a breakpoint of our
 // choosing, and with the additional responsive suffix (e.g. `\@large`).
 
-@mixin widths($columns, $breakpoint: null) {
+@mixin supercell($columns, $breakpoint: null) {
 
   // Loop through the number of columns for each denominator of our fractions.
   @each $denominator in $columns {
@@ -78,4 +78,13 @@
 
   }
 
+}
+
+// In order to support the legacy `widths()` mixin, let’s create a simple
+// wrapper around the new `supercell()` mixin. This allows developers to use the
+// older Supercell API. This will be removed in 2.0.0.
+@mixin widths($args...) {
+  @include supercell($args...);
+
+  @warn "Support for `widths()` will be removed in Supercell @2.0.0. Use `supercell()` instead."
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercell",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Grid-like layout system.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
The name `widths()` wasn’t great, and is likely to cause collisions with
other libraries. Renamed the `widths()` mixin to `supercell()` and also
provided a wrapper around the new mixin in order to provide legacy
support up until Supercell 2.0.0