### PR TITLE
Add auto width class

### DIFF
--- a/_tools.widths.scss
+++ b/_tools.widths.scss
@@ -39,6 +39,13 @@
 
 @mixin supercell($columns, $breakpoint: null) {
 
+  /**
+   * Generate an auto width utility class at each of our breakpoints.
+   */
+  .u-width-auto#{$breakpoint} {
+    width: auto !important;
+  }
+
   // Loop through the number of columns for each denominator of our fractions.
   @each $denominator in $columns {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercell",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Grid-like layout system.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Whilst we’re looping over lots of different numbers, we can quite easily
just drop an `auto` in there as well, which will also pick up on our
breakpoints. Closes #19.